### PR TITLE
[WIP] UT-120 Markdown Parser 

### DIFF
--- a/src/services/common/markdown/plugins/fix-html-breaks.js
+++ b/src/services/common/markdown/plugins/fix-html-breaks.js
@@ -3,7 +3,7 @@
  */
 
 // regex for matching HTML blocks.
-const blockExpression = /^(<(h[0-9]|div|hr|p|center|ul|li|a)([^>]+)?>)/gim
+const blockExpression = /^(<(h[0-9]|div|hr|p|center|ul|li|a|b)([^>]+)?>)/gim
 
 // fix a block contents.
 const fixBlockState = (state) => {

--- a/src/services/common/markdown/plugins/fix-html-breaks.js
+++ b/src/services/common/markdown/plugins/fix-html-breaks.js
@@ -5,9 +5,13 @@
 // regex for matching HTML blocks.
 const blockExpression = /^(<(h[0-9]|div|hr|p|center|ul|li|a|b)([^>]+)?>)/gim
 
+// remove </b> tags to ensure parsing of text. 
+const breaksExpresson = /^(<\/ ?b>)+/gim
+
 // fix a block contents.
 const fixBlockState = (state) => {
   // wrap block elements tags with new lines.
+  state.src = state.src.replace(breaksExpresson, (math) => '')
   state.src = state.src.replace(blockExpression, (match) => `${match}\n\n`)
 }
 

--- a/src/services/common/markdown/plugins/fix-html-breaks.js
+++ b/src/services/common/markdown/plugins/fix-html-breaks.js
@@ -8,7 +8,7 @@ const blockExpression = /^(<(h[0-9]|div|hr|p|center|ul|li|a)([^>]+)?>)/gim
 // fix a block contents.
 const fixBlockState = (state) => {
   // wrap block elements tags with new lines.
-  state.src = state.src.replace(blockExpression, (match) => `${match}\n`)
+  state.src = state.src.replace(blockExpression, (match) => `${match}\n\n`)
 }
 
 // plugin apply method.

--- a/src/services/common/markdown/plugins/imagefy.js
+++ b/src/services/common/markdown/plugins/imagefy.js
@@ -28,10 +28,10 @@ const defaultOptions = {
  */
 export default function (md, options = {}) {
   // parse plugin options.
-  const { proxyURL, wrapper } = Object.assign({}, defaultOptions, options)
+  const { proxyURL } = Object.assign({}, defaultOptions, options)
 
   // wrap new line elements around the value.
-  const generateImageElement = (imageURL = '') => `${wrapper}![](${imageURL})${wrapper}`
+  const generateImageElement = (imageURL = '') => `![](${imageURL})`
 
   // proxy the image using steem images.
   const proxyImage = (toProxy = '') => `${proxyURL}${toProxy}`

--- a/src/services/common/markdown/plugins/imagefy.js
+++ b/src/services/common/markdown/plugins/imagefy.js
@@ -15,9 +15,10 @@ const urlRegex = new RegExp(url, 'ig')
 // default options.
 const defaultOptions = {
   // image proxy URL prefix.
-  proxyURL: 'https://steemitimages.com/0x0/',
+  proxyURL: 'https://steemitimages.com/0x0/'
   // wrap image elements by double new lines to avoid parsing errors.
-  wrapper: '\n\n'
+  // wrapper: '\n\n'
+  // removed wrapper for the sake of table for now.
 }
 
 /**

--- a/src/services/common/markdown/utils/regex.js
+++ b/src/services/common/markdown/utils/regex.js
@@ -17,7 +17,7 @@ const urlSet = ({ domain = domainPath, path } = {}) => {
 // simple image URL pattern.
 export const image = urlSet({ domain: domainPath, path: imagePath })
 // markdown image pattern (this pattern also matches non-markdown image URLs).
-export const markdownImage = '(?:!\\[(?:.+)?\\]\\()?(' + image + ')(?:\\))?'
+export const markdownImage = '(?:!\\[[^\\]]*\\]\\()?(' + image + ')(?:\\))?'
 // html image pattern.
 export const htmlImage = '<img\\s+[^>]*src="(' + image + ')"[^>]*>'
 // simple URL pattern.


### PR DESCRIPTION
WIP Please do not merge
![markdown-issue](https://user-images.githubusercontent.com/22513880/43107645-0316d550-8eac-11e8-8515-fc310a73d1f6.png)

Problem with parser came from image above.  When parsing images in a table, the regex would capture more than one image.  In this image, it is capturing three different images and then putting them into a new HTML image element.  It was also removing the "|" characters for the table and adding a bunch of line breaks which caused the table not to be generated. In the future, it might be worth adding some logic to determine if the images are inside of a table or not.  For now this is a band-aid solution however. 
