### PR TITLE
Add Login from Cookies

### DIFF
--- a/packages/browser-extension/gulpfile.babel.js
+++ b/packages/browser-extension/gulpfile.babel.js
@@ -128,6 +128,7 @@ const mergeAll = (dest) => {
 const buildJS = (target) => {
   const files = [
     'background.js',
+    'contentscript.js',
     'options.js',
     'popup.js',
     'livereload.js'

--- a/packages/browser-extension/manifest.json
+++ b/packages/browser-extension/manifest.json
@@ -15,7 +15,9 @@
   },
   "permissions": [
     "tabs",
-    "storage"
+    "storage",
+    "cookies",
+    "http://*.utopian.io/"
   ],
   "options_ui": {
     "page": "options.html"

--- a/packages/browser-extension/package.json
+++ b/packages/browser-extension/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "bootstrap": "^4.1.3",
     "jquery": "^3.3.1",
+    "jwt-decode": "^2.2.0",
     "popper.js": "^1.14.4"
   }
 }

--- a/packages/browser-extension/src/scripts/background.js
+++ b/packages/browser-extension/src/scripts/background.js
@@ -1,12 +1,1 @@
-import ext from "./utils/ext";
-
-ext.runtime.onMessage.addListener(
-  (request, sender, sendResponse) => {
-    if(request.action === "perform-save") {
-      console.log("Extension Type: ", "/* @echo extension */");
-      console.log("PERFORM AJAX", request.data);
-
-      sendResponse({ action: "saved" });
-    }
-  }
-);
+console.log('This is running somewhere in the background')

--- a/packages/browser-extension/src/scripts/contentscript.js
+++ b/packages/browser-extension/src/scripts/contentscript.js
@@ -1,0 +1,1 @@
+console.log('This is Content Script')

--- a/packages/browser-extension/src/scripts/popup.js
+++ b/packages/browser-extension/src/scripts/popup.js
@@ -2,9 +2,9 @@ import ext from "./utils/ext";
 import storage from "./utils/storage";
 import jquery from 'jquery';
 window.$ = window.jquery = jquery;
-console.log($, jquery)
 import Popper from 'popper.js';
 import 'bootstrap';
+import { setCookie } from './utils/helpers'
 
 const popup = document.getElementById("app");
 
@@ -14,6 +14,13 @@ storage.get('color', (resp) => {
     popup.style.backgroundColor = color
   }
 });
+
+window.onload = async () => {
+  await setCookie()
+  const token = localStorage.getItem('token')
+  if (!token) console.log('User is not logged in')
+  else console.log('User is logged in')
+}
 
 const optionsLink = document.querySelector(".js-options");
 optionsLink.addEventListener("click", (e) => {

--- a/packages/browser-extension/src/scripts/utils/ext.js
+++ b/packages/browser-extension/src/scripts/utils/ext.js
@@ -22,10 +22,10 @@ const apis = [
   'windows',
 ]
 
-const Extension = () => {
+function Extension () {
   const _this = this
 
-  apis.forEach((api) => {
+  apis.forEach(function (api) {
 
     _this[api] = null
 

--- a/packages/browser-extension/src/scripts/utils/helpers.js
+++ b/packages/browser-extension/src/scripts/utils/helpers.js
@@ -1,0 +1,25 @@
+import ext from './ext'
+import decode from 'jwt-decode'
+
+export const setCookie = async () => {
+  return new Promise((resolve, reject) => {
+    ext.cookies.get({ url: 'http://staging.utopian.io', name: 'access_token' }, (cookies) => {
+      if (!cookies) {
+        localStorage.removeItem('token')
+        localStorage.removeItem('username')
+        return resolve(false)
+      }
+      const { iss, username, exp, scopes } = decode(cookies.value)
+      if (iss === 'utopian.io' && exp < Date.now() && scopes.includes('app')) {
+        localStorage.setItem('token', cookies.value)
+        localStorage.setItem('username', username)
+        resolve(true)
+      }
+      else {
+        localStorage.removeItem('token')
+        localStorage.removeItem('username')
+        resolve(false)
+      }
+    })
+  })
+}

--- a/packages/browser-extension/yarn.lock
+++ b/packages/browser-extension/yarn.lock
@@ -2899,6 +2899,10 @@ jszip@^2.4.0:
   dependencies:
     pako "~1.0.2"
 
+jwt-decode@^2.2.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/jwt-decode/-/jwt-decode-2.2.0.tgz#7d86bd56679f58ce6a84704a657dd392bba81a79"
+
 kind-of@^1.1.0:
   version "1.1.0"
   resolved "http://registry.npmjs.org/kind-of/-/kind-of-1.1.0.tgz#140a3d2d41a36d2efcfa9377b62c24f8495a5c44"


### PR DESCRIPTION
Test Plan -
- Pull the latest changes
- Install dependencies
- Run Extension by running `yarn run chrome-watch`
- Load unpacked extension from `packages/browser-extension/build/chrome`
- You can try logging in and logging out from `staging.utopian.io`
- You can check logged in user in `localstorage` of the extension or inspect popup console
- If the user is logged in then in console the user would be shown `Logged in` if the user is logged out it will show `Logged out`