### PR TITLE
The dropdown goes behind content

### DIFF
--- a/packages/i18n/components/i18n-dropdown-switcher.vue
+++ b/packages/i18n/components/i18n-dropdown-switcher.vue
@@ -34,7 +34,7 @@ div
     flat
     dense
   )
-  q-popover.user-menu(self="top right", anchor="bottom right", :offset="[ 0, 12 ]", style="z-index:1")
+  q-popover.user-menu(self="top right", anchor="bottom right", :offset="[ 0, 12 ]", style="z-index:500")
     q-list(dense, separator)
       q-item(
         link


### PR DESCRIPTION
The dropdown goes behind the carousel in the homepage, it needs to be on top of everything

### **Test plan**

Use the dropdown on the HP